### PR TITLE
fix includes by using unsafe mode and convertFile

### DIFF
--- a/src/main/scala/pl/project13/scala/sbt/SbtAsciidoctor.scala
+++ b/src/main/scala/pl/project13/scala/sbt/SbtAsciidoctor.scala
@@ -67,6 +67,7 @@ object SbtAsciidoctor extends AutoPlugin {
     options in AsciiDoctor := {
       import org.asciidoctor.Options._
       Map(
+        "safe" -> org.asciidoctor.SafeMode.UNSAFE,
         "assetsdir" -> (assetsDir in AsciiDoctor).value,
         "stylesdir" -> (stylesDir in AsciiDoctor).value,
         "stylesheet" -> (stylesheet in AsciiDoctor).value,
@@ -152,15 +153,18 @@ object SbtAsciidoctor extends AutoPlugin {
   }
 
   private def writeToFile(options: util.HashMap[String, AnyRef], adocFile: File, outFile: File): File = {
-    val reader = new BufferedReader(new FileReader(adocFile))
-    val writer = new FileWriter(outFile)
-    try {
-      engine.convert(reader, writer, options)
-      outFile
-    } finally {
-      reader.close()
-      writer.close()
-    }
+    // NOTE Asciidoctor will set the baseDir to the directory of the input file when using convertFile
+    engine.convertFile(adocFile, options)
+    outFile
+    //val reader = new BufferedReader(new FileReader(adocFile))
+    //val writer = new FileWriter(outFile)
+    //try {
+    //  engine.convert(reader, writer, options)
+    //  outFile
+    //} finally {
+    //  reader.close()
+    //  writer.close()
+    //}
   }
 
   override lazy val projectSettings = inConfig(Compile)(asciidoctorSettings)

--- a/src/sbt-test/sbt-asciidoctor/simple-doc/src/adoc/actors/actors.adoc
+++ b/src/sbt-test/sbt-asciidoctor/simple-doc/src/adoc/actors/actors.adoc
@@ -1,7 +1,7 @@
 = Actors
 
 :sectanchors:
-:sourcedir: ../../test/scala/akka/actor
+:sourcedir: ../../test/scala
 :scaladoc-import_0: akka.actor._
 
 = Actors
@@ -39,7 +39,7 @@ along with the implementation of how the messages should be processed.
 Here is an example:
 
 [source]
-include::{sourcedir}/actor/ActorDocSpec.scala[tags=my-actor]
+include::{sourcedir}/akka/actor/ActorDocSpec.scala[tags=my-actor]
 
 [source]
 ----

--- a/src/sbt-test/sbt-asciidoctor/simple-doc/src/adoc/example.adoc
+++ b/src/sbt-test/sbt-asciidoctor/simple-doc/src/adoc/example.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :sectanchors:
 :sectlinks:
-:source-highlighter: pygments
+//:source-highlighter: pygments
 :experimental:
 :mdash: &#8212;
 :language: asciidoc

--- a/src/sbt-test/sbt-asciidoctor/simple-doc/src/adoc/index.adoc
+++ b/src/sbt-test/sbt-asciidoctor/simple-doc/src/adoc/index.adoc
@@ -4,7 +4,7 @@
 :idseparator: -
 :sectanchors:
 :sectlinks:
-:source-highlighter: pygments
+//:source-highlighter: pygments
 :experimental:
 :mdash: &#8212;
 :language: asciidoc


### PR DESCRIPTION
- set safe mode to unsafe to enable includes with arbitrary paths
- use convertFile to set baseDir to match directory of input file
- disable pygments as source-highlighter (not supported in AsciidoctorJ)
- fix include paths
