### PR TITLE
Removed passing a class loader to Asciidoctor.Factory.create() and se…

### DIFF
--- a/src/main/scala/pl/project13/scala/sbt/SbtAsciidoctor.scala
+++ b/src/main/scala/pl/project13/scala/sbt/SbtAsciidoctor.scala
@@ -48,7 +48,15 @@ object SbtAsciidoctor extends AutoPlugin {
   }
   import pl.project13.scala.sbt.SbtAsciidoctor.autoImport._
 
-  private lazy val engine = org.asciidoctor.Asciidoctor.Factory.create(getClass.getClassLoader)
+  private lazy val engine = {
+    val oldTccl = Thread.currentThread().getContextClassLoader()
+    try {
+      Thread.currentThread().setContextClassLoader(getClass().getClassLoader())
+      org.asciidoctor.Asciidoctor.Factory.create()
+    } finally {
+      Thread.currentThread().setContextClassLoader(oldTccl)
+    }
+  }
 
 
   lazy val asciidoctorSettings = Seq(

--- a/src/sbt-test/sbt-asciidoctor/simple-doc/test
+++ b/src/sbt-test/sbt-asciidoctor/simple-doc/test
@@ -1,3 +1,3 @@
 > compile
 
-$ exists src/adoc/example.adoc.html
+$ exists src/adoc/example.html


### PR DESCRIPTION
…t the TCCL before Asciidoctor instantiation.
This method will be deprecated in the future.
With Asciidoctor 1.5.2 this has the problem that multiple Asciidoctor instances share the same extension registry (See https://github.com/asciidoctor/asciidoctorj/issues/339)

`sbt scripted` did not work for me initially as the file name was imo wrong in the test file.
Fixed it from `example.adoc.html` to `example.html`.
